### PR TITLE
fix(gitsubmodules): prevent timeout failure when updating submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,15 +1,15 @@
 [submodule "depends/gtest"]
 	path = depends/gtest
-	url = git://github.com/google/googletest.git
+	url = https://github.com/google/googletest.git
 [submodule "depends/ate-pairing"]
 	path = depends/ate-pairing
-	url = git://github.com/herumi/ate-pairing.git
+	url = https://github.com/herumi/ate-pairing.git
 [submodule "depends/xbyak"]
 	path = depends/xbyak
-	url = git://github.com/herumi/xbyak.git
+	url = https://github.com/herumi/xbyak.git
 [submodule "depends/libsnark-supercop"]
 	path = depends/libsnark-supercop
-	url = git://github.com/mbbarbosa/libsnark-supercop.git
+	url = https://github.com/mbbarbosa/libsnark-supercop.git
 [submodule "depends/libff"]
 	path = depends/libff
 	url = https://github.com/scipr-lab/libff.git


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`yarn build`) was run locally in root directory and any changes were pushed
- [ ] Lint (`yarn lint:fix`) was run locally in root directory and any changes were pushed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The submodule URLs in .gitmodules start with `git://`, which can sometimes encounter timeout error when updating submodules by `git submodule init && git submodule update` on `./lattice-zksnark/depends/libsnark` directory.

This error also appears when using `git submodule update --init --recursive` to update submodules on `./lattice-zksnark` directory.

## What is the new behavior?

All submodule URLs in .gitmodules have been changed from `git://` into `https://`. This prevents timeout failure when updating submodules.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No